### PR TITLE
add restore function to simulate and android

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,19 @@ function EnablePurchaseEvents() {
 
 ## Restoring Purchases
 
-In order to ship an app with in-app purchases other than "Consumable" on the iOS App Store, you are required to include a [Restore Purchases] button, which must query the App Store for past purchases made from the same Apple ID and restore them in the game.  The way to implement this button is by using the `billing.restore` function.
+In order to ship an app with in-app purchases other than "Consumable" on the iOS
+App Store, you are required to include a [Restore Purchases] button, which must
+query the App Store for past purchases made from the same Apple ID and restore
+them in the game.  The way to implement this button is by using the
+`billing.restore` function.
 
-Note that on iOS you do not need to do this if all of your purchases are consumable.
+Note that on iOS you do not need to do this if all of your purchases are
+consumable.
+
+On iOS, this functions by calling the [StoreKit
+`restoreCompletedTransactions`](https://developer.apple.com/library/ios/documentation/StoreKit/Reference/SKPaymentQueue_Class/index.html#//apple_ref/occ/instm/SKPaymentQueue/restoreCompletedTransactions)
+function on ios, then fires the `billing.onPurchase` callback for each old
+purchase. On android, this does nothing.
 
 ~~~
 billing.restore(function(err) {
@@ -338,11 +348,19 @@ Parameters
 Returns
 :    `void`
 
-Initiate restoring old purchases.  These will only restore "managed" purchases set up for your application that are tracked by the app store servers.  Consumable purchases will be lost if local storage is wiped for any reason.
+Initiate restoring old purchases.  These will only restore "managed" purchases
+set up for your application that are tracked by the app store servers.
+Consumable purchases will be lost if local storage is wiped for any reason.
 
-Your `billing.onPurchase` callback will be called for each old purchase.
+This functions by calling the [StoreKit
+`restoreCompletedTransactions`](https://developer.apple.com/library/ios/documentation/StoreKit/Reference/SKPaymentQueue_Class/index.html#//apple_ref/occ/instm/SKPaymentQueue/restoreCompletedTransactions)
+function on ios, then fires the `billing.onPurchase` callback for each old
+purchase.
 
 When restoration completes, the optional callback provided to `billing.restore` will be invoked.
+
+NOTE: this is only implemented for the ios App Store. On android, this returns
+immediately with a 'not implemented on android' failure.
 
 ~~~
 billing.restore(function(err) {

--- a/android/BillingPlugin.java
+++ b/android/BillingPlugin.java
@@ -94,6 +94,14 @@ public class BillingPlugin implements IPlugin {
 		}
 	}
 
+	public class RestoreEvent extends com.tealeaf.event.Event {
+		String failure;
+		public RestoreEvent(String failure) {
+			super("billingRestore");
+			this.failure = failure;
+		}
+	}
+
 	public BillingPlugin() {
 	}
 
@@ -404,6 +412,11 @@ public class BillingPlugin implements IPlugin {
 				EventQueue.pushEvent(new PurchaseEvent(null, null, null, null, "failed"));
 			}
 		}
+	}
+
+	public void restoreCompleted(String jsonData) {
+		logger.log("{billing} WARNING: Restore does nothing on android");
+		EventQueue.pushEvent(new RestoreEvent("not implemented for android"));
 	}
 
 	public void onNewIntent(Intent intent) {

--- a/js/index.js
+++ b/js/index.js
@@ -244,6 +244,10 @@ function onMarketStateChange() {
 // If just simulating native device,
 if (!GLOBAL.NATIVE || device.isSimulator || DEBUG) {
 	logger.log("Installing fake billing API");
+	billing.restore = function (cb) {
+		logger.log("{billing} simulating billing.restore");
+		setTimeout(function () { cb && cb(); }, 2000);
+	};
 } else {
 	logger.log("Installing JS billing component for native");
 
@@ -282,7 +286,6 @@ if (!GLOBAL.NATIVE || device.isSimulator || DEBUG) {
 
 	Billing.prototype.restore = function(cb) {
 		NATIVE.plugins.sendEvent("BillingPlugin", "restoreCompleted", "{}");
-
 		onRestore = cb;
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devkit-billing",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "devkit": {
     "clientPaths": {
       "billing": "js"


### PR DESCRIPTION
Does not add functionality - simply adds the missing functions so the
api is consistent across each environment.

NOTE: does not actually do anything in either the simulator or on
android. In the simulator this simply creates a fake function that
calls the callback after waiting 2 seconds. On Android this adds
a billingRestore event that gets sent immediately with failure 'not
implemented on android'.
