### PR TITLE
Added currencyCode properties for localization

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ purchases: {
     store_id_for_item: {
         title: 'localized title for this item',
         description: 'localized description for this item',
-        displayPrice: 'localized price for item, including currency symbol'
+        displayPrice: 'localized price for item, including currency symbol',
+        currencyCode: 'localized currency code, ie: USD, GBP, EUR...'
     },
     ...
 }
@@ -245,7 +246,8 @@ billing.on("PurchasesLocalized", function (data) {
         itemId,
         item.displayPrice,
         item.title,
-        item.description
+        item.description,
+        item.currencyCode
     );
   }
 });

--- a/android/BillingPlugin.java
+++ b/android/BillingPlugin.java
@@ -118,7 +118,7 @@ public class BillingPlugin implements IPlugin {
 	}
 
 	public class PurchasesLocalizedEvent extends com.tealeaf.event.Event {
-		ArrayList<String> skus, titles, descriptions, displayPrices;
+		ArrayList<String> skus, titles, descriptions, displayPrices, currencyCodes;
 		String failure;
 
 		public PurchasesLocalizedEvent(
@@ -126,12 +126,14 @@ public class BillingPlugin implements IPlugin {
 				ArrayList<String> titles,
 				ArrayList<String> descriptions,
 				ArrayList<String> displayPrices,
+				ArrayList<String> currencyCodes,
 				String failure) {
 			super("purchasesLocalized");
 			this.skus = skus;
 			this.titles = titles;
 			this.descriptions = descriptions;
 			this.displayPrices = displayPrices;
+			this.currencyCodes = currencyCodes;
 			this.failure = failure;
 		}
 	}
@@ -459,6 +461,7 @@ public class BillingPlugin implements IPlugin {
 		ArrayList<String> titles = new ArrayList<String>();
 		ArrayList<String> descriptions = new ArrayList<String>();
 		ArrayList<String> displayPrices = new ArrayList<String>();
+		ArrayList<String> currencyCodes = new ArrayList<String>();
 
 		JSONArray items = null;
 		ArrayList<String> itemList = new ArrayList<String> ();
@@ -481,7 +484,7 @@ public class BillingPlugin implements IPlugin {
 			if (mService == null) {
 				logger.log("{billing} WARNING: Market not available; localization request abandoned");
 				EventQueue.pushEvent(new PurchasesLocalizedEvent(
-							null, null, null, null, "failed"
+							null, null, null, null, null, "failed"
 						)
 					);
 				return;
@@ -531,6 +534,7 @@ public class BillingPlugin implements IPlugin {
 						titles.add(object.getString("title"));
 						descriptions.add(object.getString("description"));
 						displayPrices.add(object.getString("price"));
+						currencyCodes.add(object.getString("price_currency_code"));
 
 						// other fields: price_amount_micros, price_currency_code
 						// http://developer.android.com/google/play/billing/billing_reference.html#getSkuDetails
@@ -539,7 +543,7 @@ public class BillingPlugin implements IPlugin {
 					logger.log("{billing} WARINNG: Exception while building localizedPurchase response:", e);
 				}
 			} else {
-				logger.log("{billing} WARNING: Non-Success response while localizing purchases");
+				logger.log("{billing} WARNING: Non-Success response while localizing purchases", response);
 				return;
 			}
 
@@ -548,7 +552,7 @@ public class BillingPlugin implements IPlugin {
 		}
 
 		EventQueue.pushEvent(new PurchasesLocalizedEvent(
-					skus, titles, descriptions, displayPrices, null
+					skus, titles, descriptions, displayPrices, currencyCodes, null
 				)
 			);
 	}

--- a/ios/BillingPlugin.mm
+++ b/ios/BillingPlugin.mm
@@ -121,9 +121,10 @@
 				currentProduct = product;
 			}
 
-			// get the formatted price
+			// get the formatted price and currencyCode
 			[numberFormatter setLocale:product.priceLocale];
 			NSString *formattedPrice = [numberFormatter stringFromNumber:product.price];
+			NSString *formattedCurrencyCode = [numberFormatter currencyCode];
 
 			// get sku - strip bundle id if possible
 			sku = product.productIdentifier;
@@ -138,6 +139,7 @@
 			[self.localizedPurchases setObject:
 				[NSDictionary dictionaryWithObjectsAndKeys:
 					formattedPrice, @"displayPrice",
+					formattedCurrencyCode, @"currencyCode",
 					product.localizedTitle, @"title",
 					product.localizedDescription, @"description",
 					nil
@@ -446,6 +448,7 @@
 	NSMutableArray *titles = [NSMutableArray array];
 	NSMutableArray *descriptions = [NSMutableArray array];
 	NSMutableArray *displayPrices = [NSMutableArray array];
+	NSMutableArray *currencyCodes = [NSMutableArray array];
 
 	for (NSString *sku in self.localizedPurchases) {
 		NSDictionary *purchase = [self.localizedPurchases objectForKey:sku];
@@ -454,6 +457,7 @@
 		[titles addObject:[purchase valueForKey:@"title"]];
 		[descriptions addObject:[purchase valueForKey:@"description"]];
 		[displayPrices addObject:[purchase valueForKey:@"displayPrice"]];
+		[currencyCodes addObject:[purchase valueForKey:@"currencyCode"]];
 	}
 
 	[[PluginManager get] dispatchJSEvent:@{
@@ -462,6 +466,7 @@
 		@"titles": titles,
 		@"descriptions": descriptions,
 		@"displayPrices": displayPrices,
+		@"currencyCodes": currencyCodes,
 		@"invalidProductIdentifiers": self.invalidProducts
 	}];
 }

--- a/js/index.js
+++ b/js/index.js
@@ -257,7 +257,8 @@ if (!GLOBAL.NATIVE || device.isSimulator || DEBUG) {
 				data.purchases[items[i]] = {
 					title: items[i] + ' localized title',
 					description: items[i] + ' localized description',
-					displayPrice: '$0.99'
+					displayPrice: '$0.99',
+					currencyCode: 'USD'
 				};
 			}
 			billing.emit('PurchasesLocalized', data);
@@ -334,7 +335,8 @@ if (!GLOBAL.NATIVE || device.isSimulator || DEBUG) {
 			data.purchases[evt.skus[i]] = {
 				title: evt.titles[i],
 				description: evt.descriptions[i],
-				displayPrice: evt.displayPrices[i]
+				displayPrice: evt.displayPrices[i],
+				currencyCode: evt.currencyCodes[i],
 			};
 		}
 		billing.emit('PurchasesLocalized', data);


### PR DESCRIPTION
Not sure about other platforms, but Facebook AppEvents requires the currencyCode in order to correctly track purchase values, ie:

FB.AppEvents.LogPurchase(priceAmount, priceCurrency, params);

Tested to work on iOS and Android.