### PR TITLE
Fix purchase on target sdk 23

### DIFF
--- a/android/BillingPlugin.java
+++ b/android/BillingPlugin.java
@@ -208,9 +208,9 @@ public class BillingPlugin implements IPlugin {
 
 		_activity = activity;
 
-		_ctx.bindService(new 
-				Intent("com.android.vending.billing.InAppBillingService.BIND"),
-				mServiceConn, Context.BIND_AUTO_CREATE);
+		Intent serviceIntent = new Intent("com.android.vending.billing.InAppBillingService.BIND");
+		serviceIntent.setPackage("com.android.vending");
+		_ctx.bindService(serviceIntent, mServiceConn, Context.BIND_AUTO_CREATE);
 	}
 
 	public void onResume() {


### PR DESCRIPTION
To protect security of billing transactions, we need to add set
intent's target package name. This is important if we are building
with target sdk 23 (android 6.0).
